### PR TITLE
Python 3 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 env: # These should match the tox env list
     - TOXENV=py26
     - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=pypy
+    - TOXENV=pypy3
 install: pip install tox --use-mirrors
 script: tox
 sudo: false

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ For a primer on pip and virtualenv, see the [Python Packaging User Guide](https:
 
 TL;DR: `pip install yelp_bytes`
 
+This module does work on Python 3, but is likely to be a no-op the vast majority of the time: Python 3 code usually works with decoded text internally, and several of the language issues this module tries to address have been fixed.
+
 
 ## Usage
 
@@ -24,11 +26,11 @@ and `to_utf8` both take an object and return its UTF-8 bytestring representation
 
     >>> euro = u'€'
 
-    >>> print yelp_bytes.from_bytes(euro.encode('UTF-8'))
+    >>> print(yelp_bytes.from_bytes(euro.encode('UTF-8')))
     €
-    >>> print yelp_bytes.from_bytes(euro.encode('cp1252'))
+    >>> print(yelp_bytes.from_bytes(euro.encode('cp1252')))
     €
-    >>> print yelp_bytes.from_bytes(euro)
+    >>> print(yelp_bytes.from_bytes(euro))
     €
 
 
@@ -37,12 +39,12 @@ encountered.
 
     python
     >>> error = AssertionError(euro)
-    >>> print error
+    >>> print(error)
     Traceback (most recent call last):
         ...
     UnicodeEncodeError: 'ascii' codec can't encode character u'\u20ac' in position 0: ordinal not in range(128)
 
-    >>> print yelp_bytes.from_utf8(error)
+    >>> print(yelp_bytes.from_utf8(error))
     €
     >>> yelp_bytes.to_utf8(error) == euro.encode('UTF-8')
     True

--- a/tests/doc_test.py
+++ b/tests/doc_test.py
@@ -1,3 +1,12 @@
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3,),
+    reason="Python 3 doesn't have the AssertionError problem",
+)
 def test_docs():
     from doctest import testfile, ELLIPSIS
     failures, _ = testfile(

--- a/tests/yelp_bytes_test.py
+++ b/tests/yelp_bytes_test.py
@@ -18,8 +18,9 @@ class UNICODE:
 class DunderCompat(object):
     # pylint: disable=no-member
     def __str__(self):
+        # Dispatch to what str() actually means on this Python version
         try:
-            if type("") is bytes:
+            if sys.version_info < (3,):
                 return self.__bytes__()
             else:
                 return self.__unicode__()

--- a/tests/yelp_bytes_test.py
+++ b/tests/yelp_bytes_test.py
@@ -15,7 +15,7 @@ class UNICODE:
     utf8 = bmp + u'🐵'  # Monkey-face emoji. This requires at least a three-byte encoding.
 
 
-class DunderCompat(object):
+class DunderCompat(object):  # pragma: no cover
     # pylint: disable=no-member
     def __str__(self):
         # Dispatch to what str() actually means on this Python version

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = yelp_bytes
 # These should match the travis env list
-envlist = py26,py27
+envlist = py26,py27,py33,py34,pypy,pypy3
 
 [testenv]
 install_command = pip install --use-wheel {opts} {packages}

--- a/yelp_bytes.py
+++ b/yelp_bytes.py
@@ -4,6 +4,8 @@ from yelp_encodings import internet
 
 internet.register()
 
+text_type = type(u"")
+
 
 def to_bytes(obj, encoding='internet'):
     """
@@ -12,11 +14,11 @@ def to_bytes(obj, encoding='internet'):
 
     This function always returns utf8-encoded bytes.
     """
-    if isinstance(obj, str):
+    if isinstance(obj, bytes):
         # In this case we have to assume it's already utf8.
         return obj
     else:
-        return unicode(obj).encode(encoding)
+        return text_type(obj).encode(encoding)
 
 
 def from_bytes(obj, encoding='internet', errors='strict'):
@@ -26,17 +28,17 @@ def from_bytes(obj, encoding='internet', errors='strict'):
 
     This function always returns unicode.
     """
-    if isinstance(obj, unicode):
+    if isinstance(obj, text_type):
         return obj
     try:
-        return unicode(obj, encoding, errors)
+        return text_type(obj, encoding, errors)
     except TypeError:
         # We're only allowed to specify an encoding for str values, for whatever reason.
         try:
-            return unicode(obj)
+            return text_type(obj)
         except UnicodeDecodeError:
             # You get this (for example) when an error object contains utf8 bytes.
-            return unicode(str(obj), encoding, errors)
+            return text_type(bytes(obj), encoding, errors)
 
 
 def to_utf8(obj):


### PR DESCRIPTION
(I don't have 2.6 or 3.3 on my machine, but I have no reason to believe that they'd act meaningfully differently.)

tox passes except for coverage, which is forced at 100%, but that's basically impossible when there are branches depending on the Python version.  I could lower the required coverage; slap a bunch of `pragma` comments all over the place; or try to rig `tox.ini` so it only does a coverage report _once_ and combines the results of all the environment runs (which should then produce 100%).  Or maybe someone else can do that last one because I don't entirely know how to do that.