### PR TITLE
Build and test with GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,26 @@
+name: Build and Test
+
+on:
+ push:
+   branches: [master]
+   tags:
+ pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['2.7', '3.5', 'pypy2.7']
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: python -m pip install tox
+
+    - name: Run ${{ matrix.python-version }} tox
+      run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ project = yelp_bytes
 envlist = py27,py34,py35,pypy,pypy3
 
 [testenv]
-install_command = pip install --use-wheel {opts} {packages}
 deps = -rrequirements-dev.txt
 commands =
     coverage erase


### PR DESCRIPTION
Since travis is no longer available, use github actions to run tests.

I'm not sure entirely sure if all these python versions are available, but I plan to drop python 2 and old versions of python 3 for newer versions of python later. I'd like the github action to validate future PRs.

Note: This only runs the build and test. coverage would be done in a different flow.
Also, I believe the action won't run until this is merged and the new flow is explicitly approved.